### PR TITLE
[FIX] This command is outdated, please try again in a few minutes

### DIFF
--- a/src/Midjourney.php
+++ b/src/Midjourney.php
@@ -4,6 +4,7 @@ namespace Ferranfg\MidjourneyPhp;
 
 use Exception;
 use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\MultipartStream;
 
 class Midjourney {
 
@@ -105,8 +106,15 @@ class Midjourney {
             ]
         ];
 
+        $multipartStream = new MultipartStream([
+            [
+                'name' => 'payload_json',
+                'contents' => json_encode($params)
+            ]
+        ]);
+
         self::$client->post('interactions', [
-            'json' => $params
+            'body' => $multipartStream
         ]);
 
         sleep(8);


### PR DESCRIPTION
This PR fixes the issue with sending the prompt to Discord which has been throwing a 400 below as of 15th June:
```log
POST https:\/\/discord.com\/api\/interactions` resulted in a `400 Bad Request` response:\n{\"data\": [\"This command is outdated, please try again in a few minutes\"]}\n"]
```
After investigating, I found that the interaction request structure had been changed from application/json to multi-part/form-data