### PR TITLE
Add timeout to photo upscaling process

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,25 +1,16 @@
 {
-    "name": "ferranfg/midjourney-php",
-    "description": "Generate images using Midjourney Bot through the Discord API.",
-    "keywords": ["midjourney", "midjourney-bot", "midjourney-api-bot"],
-    "license": "MIT",
-    "support": {
-        "issues": "https://github.com/ferranfg/midjourney-discord-api-php/issues",
-        "source": "https://github.com/ferranfg/midjourney-discord-api-php"
-    },
-    "autoload": {
-        "psr-4": {
-            "Ferranfg\\MidjourneyPhp\\": "src/"
-        }
-    },
-    "authors": [
-        {
-            "name": "ferran figueredo",
-            "email": "hola@ferranfigueredo.com"
-        }
-    ],
-    "require": {
-        "php": "^8.1",
-        "guzzlehttp/guzzle": "^7.5"
+  "require": {
+    "ajaska-gmbh/midjourney-discord-api-php": "main"
+  },
+  "repositories": [
+    {
+      "type": "vcs",
+      "name": "ajaska-gmbh/midjourney-discord-api-php",
+      "url": "https://github.com/ajaska-gmbh/midjourney-discord-api-php"
     }
-}
+  ],
+  "config": {
+    "preferred-install": {
+      "ajaska-gmbh/*": "source"
+    }
+  }

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,25 @@
 {
-  "require": {
-    "ajaska-gmbh/midjourney-discord-api-php": "main"
-  },
-  "repositories": [
-    {
-      "type": "vcs",
-      "name": "ajaska-gmbh/midjourney-discord-api-php",
-      "url": "https://github.com/ajaska-gmbh/midjourney-discord-api-php"
+    "name": "ferranfg/midjourney-php",
+    "description": "Generate images using Midjourney Bot through the Discord API.",
+    "keywords": ["midjourney", "midjourney-bot", "midjourney-api-bot"],
+    "license": "MIT",
+    "support": {
+        "issues": "https://github.com/ferranfg/midjourney-discord-api-php/issues",
+        "source": "https://github.com/ferranfg/midjourney-discord-api-php"
+    },
+    "autoload": {
+        "psr-4": {
+            "Ferranfg\\MidjourneyPhp\\": "src/"
+        }
+    },
+    "authors": [
+        {
+            "name": "ferran figueredo",
+            "email": "hola@ferranfigueredo.com"
+        }
+    ],
+    "require": {
+        "php": "^8.1",
+        "guzzlehttp/guzzle": "^7.5"
     }
-  ],
-  "config": {
-    "preferred-install": {
-      "ajaska-gmbh/*": "source"
-    }
-  }
+}

--- a/src/Midjourney.php
+++ b/src/Midjourney.php
@@ -188,11 +188,20 @@ class Midjourney {
 
         $upscaled_photo_url = null;
 
+        $startTime = time();
+        $max_time_to_find_upscaled_link = 60 * 5;
+
         while (is_null($upscaled_photo_url))
         {
             $upscaled_photo_url = $this->getUpscale($message, $upscale_index);
 
-            if (is_null($upscaled_photo_url)) sleep(3);
+            if (is_null($upscaled_photo_url)) {
+                sleep(3);
+
+                if ((time() - $startTime) >= $max_time_to_find_upscaled_link) {
+                    throw new Exception("Upscale photo URL could not be found within the specified time limit.");
+                }
+            }
         }
 
         return $upscaled_photo_url;


### PR DESCRIPTION
# Add timeout to photo upscaling process

In this Pull Request, I have addressed an issue where the **application could potentially hang indefinitely during the photo upscaling process**.

Previously, the `getUpscale` function was invoked within a `while` loop without any timeout mechanism. If `getUpscale` persistently returned `null` (in cases where the upscaling process fails), the loop wouldn't terminate, causing the application to stay in waiting indefinitely.

To resolve this, I've introduced a `startTime` variable and a `max_time_to_find_upscaled_link` to create a maximum execution time for the upscaling process.

Now, when the `getUpscale` function fails to find a non-null `upscaled_photo_url` within the specified `max_time_to_find_upscaled_link`, it throws an Exception and gracefully exits, thereby allowing the rest of the application to continue its operation.

This change enhances the robustness of the application by ensuring that a setback in the upscaling process doesn't halt the completion of the entire script.